### PR TITLE
Verbose error

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package tus
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 )
@@ -106,7 +107,7 @@ func (c *Client) CreateUpload(u *Upload) (*Uploader, error) {
 	case 413:
 		return nil, ErrLargeUpload
 	default:
-		return nil, ClientError{res.StatusCode}
+		return nil, newClientError(res)
 	}
 }
 
@@ -198,7 +199,7 @@ func (c *Client) uploadChunck(url string, body io.Reader, size int64, offset int
 	case 413:
 		return -1, ErrLargeUpload
 	default:
-		return -1, ClientError{res.StatusCode}
+		return -1, newClientError(res)
 	}
 }
 
@@ -231,6 +232,14 @@ func (c *Client) getUploadOffset(url string) (int64, error) {
 	case 412:
 		return -1, ErrVersionMismatch
 	default:
-		return -1, ClientError{res.StatusCode}
+		return -1, newClientError(res)
+	}
+}
+
+func newClientError(res *http.Response) ClientError {
+	body, _ := ioutil.ReadAll(res.Body)
+	return ClientError{
+		Code: res.StatusCode,
+		Body: string(body),
 	}
 }

--- a/client.go
+++ b/client.go
@@ -240,6 +240,6 @@ func newClientError(res *http.Response) ClientError {
 	body, _ := ioutil.ReadAll(res.Body)
 	return ClientError{
 		Code: res.StatusCode,
-		Body: string(body),
+		Body: body,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -90,6 +90,7 @@ func (c *Client) CreateUpload(u *Upload) (*Uploader, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	switch res.StatusCode {
 	case 201:
@@ -181,6 +182,7 @@ func (c *Client) uploadChunck(url string, body io.Reader, size int64, offset int
 	if err != nil {
 		return -1, err
 	}
+	defer res.Body.Close()
 
 	switch res.StatusCode {
 	case 204:
@@ -212,6 +214,7 @@ func (c *Client) getUploadOffset(url string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
+	defer res.Body.Close()
 
 	switch res.StatusCode {
 	case 200:

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ var (
 
 type ClientError struct {
 	Code int
-	Body string
+	Body []byte
 }
 
 func (c ClientError) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,7 @@ var (
 
 type ClientError struct {
 	Code int
+	Body string
 }
 
 func (c ClientError) Error() string {


### PR DESCRIPTION
Hi,

first of all, **thanks for this library**!

I have a Tus server, which does some validation before accepting an upload (constraints on the filename for instance), and I need to get more than the status code to display a helpful error to the user.

**This PR** adds a `Body` field to the `ClientError`, which contains the body of the failed request, to allow my program to achieve this.

It **breaks the compatibility** if someone is building the `ClientError` struct outside of the library (but I don't see any reason, why someone would do this).

It also **contains a minor fix**, since the `Body` of a http.Response should always be closed (when there was no error doing the request)