### PR TITLE
Change Transport to http.RoundTripper to allow for other implementations of Transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.6
-  - 1.7
   - 1.8
   - 1.9
   - tip

--- a/config.go
+++ b/config.go
@@ -18,8 +18,8 @@ type Config struct {
 	// Set custom header values used in all requests.
 	Header http.Header
 	// Set custom Transport settings.
-	// Use this if you ahe behind a proxy.
-	Transport *http.Transport
+	// Use this if you are behind a proxy.
+	Transport http.RoundTripper
 }
 
 // DefaultConfig return the default Client configuration.


### PR DESCRIPTION
this allows for `&http2.Transport` in addition to just `&http.Transport`