### PR TITLE
After aborting, msg should not be sent to subscribed channels

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -90,6 +90,9 @@ func (u *Uploader) UploadChunck() error {
 func (u *Uploader) broadcastProgress() {
 	for _ = range u.notifyChan {
 		for _, c := range u.uploadSubs {
+			if u.IsAborted() {
+				return
+			}
 			c <- *u.upload
 		}
 	}


### PR DESCRIPTION
Otherwise crash will be seen because msg is sent over closed chan. 