### PR TITLE
Support for the Location to be a relative URL

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,6 @@ var (
 	ErrUploadNotFound    = errors.New("upload not found.")
 	ErrResumeNotEnabled  = errors.New("resuming not enabled.")
 	ErrFingerprintNotSet = errors.New("fingerprint not set.")
-	ErrUrlNotRecognized  = errors.New("url not recognized")
 )
 
 type ClientError struct {


### PR DESCRIPTION
Hi and many thanks for a really nice and straight forward to use TUS client lib.
I noticed that some TUS servers return a location that is just a path.
It is indeed a valid case mentioned by the spec:

> The Server MUST set the Location header to the URL of the created resource. This URL MAY be absolute or relative.
https://tus.io/protocols/resumable-upload.html#creation

This patch supports the case where the location value is a relative URL.