### PR TITLE
Allow Relative URL in Location Header

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	netUrl "net/url"
+	"path"
 	"strconv"
 )
 
@@ -97,15 +98,19 @@ func (c *Client) CreateUpload(u *Upload) (*Uploader, error) {
 			return nil, ErrUrlNotRecognized
 		}
 
-		newUrl, err := netUrl.Parse(url)
-		if err != nil {
-			return nil, ErrUrlNotRecognized
+		if c.Config.RelativeURL {
+			baseUrl.Path = path.Join(baseUrl.Path, url)
+			url = baseUrl.String()
+		} else {
+			newUrl, err := netUrl.Parse(url)
+			if err != nil {
+				return nil, ErrUrlNotRecognized
+			}
+			if newUrl.Scheme == "" {
+				newUrl.Scheme = baseUrl.Scheme
+				url = newUrl.String()
+			}
 		}
-		if newUrl.Scheme == "" {
-			newUrl.Scheme = baseUrl.Scheme
-			url = newUrl.String()
-		}
-
 		if c.Config.Resume {
 			c.Config.Store.Set(u.Fingerprint, url)
 		}

--- a/client.go
+++ b/client.go
@@ -98,18 +98,13 @@ func (c *Client) CreateUpload(u *Upload) (*Uploader, error) {
 			return nil, ErrUrlNotRecognized
 		}
 
-		if c.Config.RelativeURL {
+		newUrl, err := netUrl.Parse(url)
+		if err != nil {
+			return nil, ErrUrlNotRecognized
+		}
+		if newUrl.Scheme == "" {
 			baseUrl.Path = path.Join(baseUrl.Path, url)
 			url = baseUrl.String()
-		} else {
-			newUrl, err := netUrl.Parse(url)
-			if err != nil {
-				return nil, ErrUrlNotRecognized
-			}
-			if newUrl.Scheme == "" {
-				newUrl.Scheme = baseUrl.Scheme
-				url = newUrl.String()
-			}
 		}
 		if c.Config.Resume {
 			c.Config.Store.Set(u.Fingerprint, url)

--- a/client_test.go
+++ b/client_test.go
@@ -264,6 +264,7 @@ func (s *UploadTestSuite) TestConcurrentUploads() {
 }
 
 func (s *UploadTestSuite) TestResumeUpload() {
+	
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/client_test.go
+++ b/client_test.go
@@ -333,10 +333,7 @@ func (s *UploadTestSuite) TestCreateUploadRelativeURL() {
 	))
 	defer srv.Close()
 
-	cfg := DefaultConfig()
-	cfg.RelativeURL = true
-
-	client, err := NewClient(srv.URL, cfg)
+	client, err := NewClient(srv.URL, DefaultConfig())
 	s.NoError(err)
 	upload, err := client.CreateUpload(NewUploadFromBytes([]byte("test")))
 	s.NoError(err)

--- a/client_test.go
+++ b/client_test.go
@@ -264,7 +264,7 @@ func (s *UploadTestSuite) TestConcurrentUploads() {
 }
 
 func (s *UploadTestSuite) TestResumeUpload() {
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -338,7 +338,7 @@ func (s *UploadTestSuite) TestCreateUploadRelativeURL() {
 	s.NoError(err)
 	upload, err := client.CreateUpload(NewUploadFromBytes([]byte("test")))
 	s.NoError(err)
-	s.Equal(srv.URL + "/xyz", upload.url)
+	s.Equal(srv.URL+"/xyz", upload.url)
 }
 
 func TestUploadTestSuite(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Resume bool
 	// OverridePatchMethod allow to by pass proxies sendind a POST request instead of PATCH.
 	OverridePatchMethod bool
+	// RelativeURL allows support for a relative Location header in the creation response
+	RelativeURL bool
 	// Store map an upload's fingerprint with the corresponding upload URL.
 	// If Resume is true the Store is required.
 	Store Store

--- a/config.go
+++ b/config.go
@@ -12,8 +12,6 @@ type Config struct {
 	Resume bool
 	// OverridePatchMethod allow to by pass proxies sendind a POST request instead of PATCH.
 	OverridePatchMethod bool
-	// RelativeURL allows support for a relative Location header in the creation response
-	RelativeURL bool
 	// Store map an upload's fingerprint with the corresponding upload URL.
 	// If Resume is true the Store is required.
 	Store Store


### PR DESCRIPTION
Fixed #43 - This passes the test suite because all responses from tusd always uses absolute paths. This COULD be a breaking change if there is some weird server implementation that returns an absolute path without a scheme.