### PR TITLE
imporve the  accuracy of debug information

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package tus
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -107,6 +108,9 @@ func (c *Client) CreateUpload(u *Upload) (*Uploader, error) {
 		return nil, ErrVersionMismatch
 	case 413:
 		return nil, ErrLargeUpload
+	case 200:
+		resBody, _ := ioutil.ReadAll(res.Body)
+		return nil, errors.New(string(resBody))
 	default:
 		return nil, newClientError(res)
 	}


### PR DESCRIPTION
should notice the response data when response code is 200.Beacuse the 2xx is successful  in theory,adding this information is helpful to debug