### PR TITLE
fix: close chan to prevent go routine leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/eventials/go-tus
+module github.com/KeesTucker/go-tus
 
 go 1.13
 

--- a/uploader.go
+++ b/uploader.go
@@ -49,6 +49,8 @@ func (u *Uploader) Upload() error {
 			return err
 		}
 	}
+	// close channel to prevent leaked goroutines due to broadcastProgress blocking.
+	close(u.notifyChan)
 
 	return nil
 }


### PR DESCRIPTION
Closes the notify chan on upload completion so that broadcastProgress func can exit, therefore cleaning up the go routine it's running on. Please see this go playground snippet for an example: https://go.dev/play/p/-HP__Mpuxn0