### PR TITLE
fix: close chan to prevent go routine leak

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -42,6 +42,7 @@ func (u *Uploader) Offset() int64 {
 
 // Upload uploads the entire body to the server.
 func (u *Uploader) Upload() error {
+	defer close(u.notifyChan)
 	for u.offset < u.upload.size && !u.aborted {
 		err := u.UploadChunck()
 


### PR DESCRIPTION
Closes the notify chan on upload completion so that broadcastProgress func can exit, therefore cleaning up the go routine it's running on. Please see this go playground snippet for an example: https://go.dev/play/p/-HP__Mpuxn0